### PR TITLE
Stateful command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "league/tactician": "^0.6.0",
         "ramsey/uuid": "^2.8",
-        "symfony/console": "^2.7"
+        "symfony/console": "^2.7",
+        "yohang/finite": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",        

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "require-dev": {
         "phpunit/phpunit": "^4.7",        
         "squizlabs/php_codesniffer": "^2.3",
-        "satooshi/php-coveralls": "^0.6.1"
+        "satooshi/php-coveralls": "^0.6.1",
+        "mockery/mockery": "^0.9.4"
     },
     "bin": [
         "bin/scheduler"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cbbbd67b3b0fa33ae1f559b996654baf",
-    "content-hash": "dab0b81dd87245e56255090df703b42a",
+    "hash": "3af23524ca35ad4701ef4537469bf34a",
+    "content-hash": "fc7cc777a8a27a03f2867fd4166c4e4b",
     "packages": [
         {
             "name": "league/tactician",
@@ -504,6 +504,116 @@
                 "web service"
             ],
             "time": "2015-03-18 18:23:50"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "reference": "b37020aa976fa52d3de9aa904aa2522dc518f79c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ],
+                "files": [
+                    "hamcrest/Hamcrest.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2015-05-11 14:41:42"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "0.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "70bba85e4aabc9449626651f48b9018ede04f86b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/70bba85e4aabc9449626651f48b9018ede04f86b",
+                "reference": "70bba85e4aabc9449626651f48b9018ede04f86b",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~1.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2015-04-02 19:54:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1882426c34c6f1bf93229fda51d97a29",
+    "hash": "cbbbd67b3b0fa33ae1f559b996654baf",
+    "content-hash": "dab0b81dd87245e56255090df703b42a",
     "packages": [
         {
             "name": "league/tactician",
@@ -128,12 +129,12 @@
             "version": "v2.7.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d6cf02fe73634c96677e428f840704bfbcaec29e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d6cf02fe73634c96677e428f840704bfbcaec29e",
                 "reference": "d6cf02fe73634c96677e428f840704bfbcaec29e",
                 "shasum": ""
             },
@@ -179,6 +180,179 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2015-07-28 15:18:12"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-18 19:21:56"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "85fd10e551677d3c9a4632def78b8ec4670b247d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/85fd10e551677d3c9a4632def78b8ec4670b247d",
+                "reference": "85fd10e551677d3c9a4632def78b8ec4670b247d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony OptionsResolver Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "time": "2015-10-11 09:39:48"
+        },
+        {
+            "name": "yohang/finite",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yohang/Finite.git",
+                "reference": "252476cdb20e6f9d93e588db1c1ec73d1619400d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yohang/Finite/zipball/252476cdb20e6f9d93e588db1c1ec73d1619400d",
+                "reference": "252476cdb20e6f9d93e588db1c1ec73d1619400d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/event-dispatcher": ">=2.1,<3.0",
+                "symfony/options-resolver": ">=2.1,<3.0"
+            },
+            "require-dev": {
+                "pdepend/pdepend": "*",
+                "phpmd/phpmd": "*",
+                "phpunit/phpunit": ">=3.7,<4.0",
+                "pimple/pimple": ">=1.0,<2.0",
+                "symfony/dependency-injection": ">=2.1,<3.0",
+                "symfony/framework-bundle": ">=2.1,<3.0",
+                "symfony/security": ">=2.1,<3.0",
+                "twig/twig": ">=1.13,<2.0"
+            },
+            "suggest": {
+                "pimple/pimple": "Needed for use with PimpleFactory",
+                "symfony/dependency-injection": "Needed for use with Symfony DependencyInjection Factory",
+                "symfony/security": "Needed for using SecurityAwareStateMachine",
+                "symfony/yaml": "Yaml allows you to define your State graph in YAML"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Finite": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Yohan Giarelli",
+                    "email": "yohan@giarel.li",
+                    "homepage": "http://yohan.giarel.li"
+                }
+            ],
+            "description": "A simple PHP5.3+ Finite State Machine",
+            "homepage": "https://github.com/yohang/Finite",
+            "keywords": [
+                "statemachine"
+            ],
+            "time": "2014-05-05 08:08:03"
         }
     ],
     "packages-dev": [
@@ -1364,12 +1538,12 @@
             "version": "v2.7.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
+                "url": "https://api.github.com/repos/symfony/config/zipball/6c905bbed1e728226de656e4c07d620dfe9e80d9",
                 "reference": "6c905bbed1e728226de656e4c07d620dfe9e80d9",
                 "shasum": ""
             },
@@ -1410,74 +1584,16 @@
             "time": "2015-07-09 16:07:40"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.7.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
-                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/stopwatch": "~2.3"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-06-18 19:21:56"
-        },
-        {
             "name": "symfony/filesystem",
             "version": "v2.7.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
                 "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
                 "shasum": ""
             },

--- a/src/Command/AbstractStatefulScheduledCommand.php
+++ b/src/Command/AbstractStatefulScheduledCommand.php
@@ -1,0 +1,39 @@
+<?php
+namespace ConnectHolland\Tactician\SchedulerPlugin\Command;
+
+use Finite\StatefulInterface;
+
+/**
+ * Stateful command to keep track of failed / succeeded scheduled commands
+ *
+ * @author Ron Rademaker
+ */
+class AbstractStatefulScheduledCommand extends AbstractScheduledCommand implements StatefulInterface
+{
+    /**
+     * The current state of the command
+     *
+     * @var string
+     */
+    private $state;
+
+    /**
+     * Gets the current state
+     *
+     * @return string
+     */
+    public function getFiniteState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * Sets the state
+     *
+     * @param string $state
+     */
+    public function setFiniteState($state)
+    {
+       $this->state = $state;
+    }
+}

--- a/src/Command/AbstractStatefulScheduledCommand.php
+++ b/src/Command/AbstractStatefulScheduledCommand.php
@@ -34,6 +34,6 @@ class AbstractStatefulScheduledCommand extends AbstractScheduledCommand implemen
      */
     public function setFiniteState($state)
     {
-       $this->state = $state;
+        $this->state = $state;
     }
 }

--- a/src/Command/AbstractStatefulScheduledCommand.php
+++ b/src/Command/AbstractStatefulScheduledCommand.php
@@ -1,14 +1,12 @@
 <?php
 namespace ConnectHolland\Tactician\SchedulerPlugin\Command;
 
-use Finite\StatefulInterface;
-
 /**
  * Stateful command to keep track of failed / succeeded scheduled commands
  *
  * @author Ron Rademaker
  */
-class AbstractStatefulScheduledCommand extends AbstractScheduledCommand implements StatefulInterface
+class AbstractStatefulScheduledCommand extends AbstractScheduledCommand implements StatefulCommandInterface
 {
     /**
      * The current state of the command

--- a/src/Command/StatefulCommandInterface.php
+++ b/src/Command/StatefulCommandInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace ConnectHolland\Tactician\SchedulerPlugin\Command;
+
+use Finite\StatefulInterface;
+
+/**
+ * Interface for stateful commands
+ *
+ * @author Ron Rademaker
+ */
+interface StatefulCommandInterface extends StatefulInterface
+{
+    
+}

--- a/src/Command/StatefulCommandInterface.php
+++ b/src/Command/StatefulCommandInterface.php
@@ -10,5 +10,4 @@ use Finite\StatefulInterface;
  */
 interface StatefulCommandInterface extends StatefulInterface
 {
-    
 }

--- a/src/Console/DaemonCommand.php
+++ b/src/Console/DaemonCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DaemonCommand extends SchedulerCommand
 {
-     /**
+    /**
      * configure.
      *
      * Sets the command variables and it's inputs

--- a/src/Factory/StatefulCommandFactory.php
+++ b/src/Factory/StatefulCommandFactory.php
@@ -1,0 +1,32 @@
+<?php
+namespace ConnectHolland\Tactician\SchedulerPlugin\Factory;
+
+use Finite\Factory\AbstractFactory;
+use Finite\StateMachine\StateMachine;
+
+/**
+ * Factory to create statemachines from a stateful command
+ *
+ * @author Ron Rademaker
+ */
+class StatefulCommandFactory extends AbstractFactory
+{
+    /**
+     * Initializes the loader for the stateful commands
+     */
+    public function __construct()
+    {
+        $this->addLoader(new StatefulCommandLoader());
+    }
+
+        /**
+     * Creates a new empty statemachine
+     *
+     * @since 1.2
+     * @return StateMachine
+     */
+    protected function createStateMachine()
+    {
+        return new StateMachine();
+    }
+}

--- a/src/Factory/StatefulCommandFactory.php
+++ b/src/Factory/StatefulCommandFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace ConnectHolland\Tactician\SchedulerPlugin\Factory;
 
+use ConnectHolland\Tactician\SchedulerPlugin\Loader\StatefulCommandLoader;
 use Finite\Factory\AbstractFactory;
 use Finite\StateMachine\StateMachine;
 

--- a/src/Loader/StatefulCommandLoader.php
+++ b/src/Loader/StatefulCommandLoader.php
@@ -1,0 +1,43 @@
+<?php
+namespace ConnectHolland\Tactician\SchedulerPlugin\Loader;
+
+use ConnectHolland\Tactician\SchedulerPlugin\Command\StatefulCommandInterface;
+use Finite\Loader\LoaderInterface;
+use Finite\State\State;
+use Finite\State\StateInterface;
+use Finite\StatefulInterface;
+use Finite\StateMachine\StateMachineInterface;
+use Finite\Transition\Transition;
+
+/**
+ * Loader to defines states, transitions and properties for stateful commands
+ *
+ * @author Ron Rademaker
+ */
+class StatefulCommandLoader implements LoaderInterface
+{
+    public function load(StateMachineInterface $stateMachine)
+    {
+       $stateMachine->addState(new State('new', StateInterface::TYPE_INITIAL));
+       $stateMachine->addState(new State('scheduled', StateInterface::TYPE_NORMAL));
+       $stateMachine->addState(new State('executing', StateInterface::TYPE_NORMAL));
+       $stateMachine->addState(new State('failed', StateInterface::TYPE_FINAL));
+       $stateMachine->addState(new State('succeeded', StateInterface::TYPE_FINAL));
+
+       $stateMachine->addTransition(new Transition('schedule', 'new', 'scheduled'));
+       $stateMachine->addTransition(new Transition('execute', 'scheduled', 'executing'));
+       $stateMachine->addTransition(new Transition('fail', 'executing', 'failed'));
+       $stateMachine->addTransition(new Transition('succeed', 'executing', 'succeeded'));
+    }
+
+    /**
+     * Returns true if object is a stateful command
+     *
+     * @param StatefulInterface $object
+     * @return boolean
+     */
+    public function supports(StatefulInterface $object)
+    {
+        return $object instanceof StatefulCommandInterface;
+    }
+}

--- a/src/Loader/StatefulCommandLoader.php
+++ b/src/Loader/StatefulCommandLoader.php
@@ -18,16 +18,16 @@ class StatefulCommandLoader implements LoaderInterface
 {
     public function load(StateMachineInterface $stateMachine)
     {
-       $stateMachine->addState(new State('new', StateInterface::TYPE_INITIAL));
-       $stateMachine->addState(new State('scheduled', StateInterface::TYPE_NORMAL));
-       $stateMachine->addState(new State('executing', StateInterface::TYPE_NORMAL));
-       $stateMachine->addState(new State('failed', StateInterface::TYPE_FINAL));
-       $stateMachine->addState(new State('succeeded', StateInterface::TYPE_FINAL));
+        $stateMachine->addState(new State('new', StateInterface::TYPE_INITIAL));
+        $stateMachine->addState(new State('scheduled', StateInterface::TYPE_NORMAL));
+        $stateMachine->addState(new State('executing', StateInterface::TYPE_NORMAL));
+        $stateMachine->addState(new State('failed', StateInterface::TYPE_FINAL));
+        $stateMachine->addState(new State('succeeded', StateInterface::TYPE_FINAL));
 
-       $stateMachine->addTransition(new Transition('schedule', 'new', 'scheduled'));
-       $stateMachine->addTransition(new Transition('execute', 'scheduled', 'executing'));
-       $stateMachine->addTransition(new Transition('fail', 'executing', 'failed'));
-       $stateMachine->addTransition(new Transition('succeed', 'executing', 'succeeded'));
+        $stateMachine->addTransition(new Transition('schedule', 'new', 'scheduled'));
+        $stateMachine->addTransition(new Transition('execute', 'scheduled', 'executing'));
+        $stateMachine->addTransition(new Transition('fail', 'executing', 'failed'));
+        $stateMachine->addTransition(new Transition('succeed', 'executing', 'succeeded'));
     }
 
     /**

--- a/src/Scheduler/StatefulAwareSchedulerInterface.php
+++ b/src/Scheduler/StatefulAwareSchedulerInterface.php
@@ -1,0 +1,26 @@
+<?php
+namespace ConnectHolland\Tactician\SchedulerPlugin\Scheduler;
+
+use ConnectHolland\Tactician\SchedulerPlugin\Command\ScheduledCommandInterface;
+
+/**
+ * Interface that defines schedulers that are aware of possible stateful commands
+ *
+ * @author Ron Rademaker
+ */
+interface StatefulAwareSchedulerInterface extends SchedulerInterface
+{
+    /**
+     * Marks the command as succeeded (if a stateful command)
+     *
+     * @param ScheduledCommandInterface $command
+     */
+    public function succeed(ScheduledCommandInterface $command);
+
+    /**
+     * Marks the command as failed (if a stateful command)
+     *
+     * @param ScheduledCommandInterface $command
+     */
+    public function fail(ScheduledCommandInterface $command);
+}

--- a/tests/Fixtures/Command/StatefulCommand.php
+++ b/tests/Fixtures/Command/StatefulCommand.php
@@ -1,0 +1,14 @@
+<?php
+namespace ConnectHolland\Tactician\SchedulerPlugin\Tests\Fixtures\Command;
+
+use ConnectHolland\Tactician\SchedulerPlugin\Command\AbstractStatefulScheduledCommand;
+
+/**
+ * Fixture stateful command
+ *
+ * @author Ron Rademaker
+ */
+class StatefulCommand extends AbstractStatefulScheduledCommand
+{
+    
+}

--- a/tests/Middleware/SchedulerMiddlewareTest.php
+++ b/tests/Middleware/SchedulerMiddlewareTest.php
@@ -166,9 +166,7 @@ class SchedulerMiddlewareTest extends AbstractFileBasedSchedulerTest
         sleep(1);
         try {
             $commandBus->handle(new ExecuteScheduledCommandsCommand($commandBus));
-        }
-        catch (Exception $e) {
-            
+        } catch (Exception $e) {
         }
 
         $resultCommand = $this->collection->findOne();

--- a/tests/Middleware/SchedulerMiddlewareTest.php
+++ b/tests/Middleware/SchedulerMiddlewareTest.php
@@ -4,9 +4,10 @@ namespace ConnectHolland\Tactician\SchedulerPlugin\Middleware\Tests;
 
 use ConnectHolland\Tactician\SchedulerPlugin\Command\ExecuteScheduledCommandsCommand;
 use ConnectHolland\Tactician\SchedulerPlugin\Middleware\SchedulerMiddleware;
-use ConnectHolland\Tactician\SchedulerPlugin\Scheduler\FileBasedScheduler;
+use ConnectHolland\Tactician\SchedulerPlugin\Scheduler\MongoScheduler;
 use ConnectHolland\Tactician\SchedulerPlugin\Tests\AbstractFileBasedSchedulerTest;
 use ConnectHolland\Tactician\SchedulerPlugin\Tests\Fixtures\Command\ScheduledCommand;
+use ConnectHolland\Tactician\SchedulerPlugin\Tests\Fixtures\Command\StatefulCommand;
 use League\Tactician\CommandBus;
 use League\Tactician\Handler\CommandHandlerMiddleware;
 use League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor;
@@ -14,6 +15,7 @@ use League\Tactician\Handler\Locator\InMemoryLocator;
 use League\Tactician\Handler\MethodNameInflector\HandleClassNameInflector;
 use League\Tactician\Tests\Fixtures\Command\AddTaskCommand;
 use League\Tactician\Tests\Fixtures\Handler\DynamicMethodsHandler;
+use MongoClient;
 
 /**
  * Unit test for the scheduler middleware.
@@ -33,6 +35,11 @@ class SchedulerMiddlewareTest extends AbstractFileBasedSchedulerTest
     private $methodHandler;
 
     /**
+     * Mongo cllection with the commands
+     */
+    private $collection;
+
+    /**
      * Creates a command bus to use for testing.
      */
     public function setUp()
@@ -45,15 +52,30 @@ class SchedulerMiddlewareTest extends AbstractFileBasedSchedulerTest
             new InMemoryLocator([
                 AddTaskCommand::class => $this->methodHandler,
                 ScheduledCommand::class => $this->methodHandler,
+                StatefulCommand::class => $this->methodHandler
             ]),
             new HandleClassNameInflector()
         );
 
-        $scheduler = new FileBasedScheduler('tests/schedulerpath');
+        $con = new MongoClient('mongodb://localhost');
+        $db = $con->selectDB('ConnectHollandTacticianSchedulerTest');
+        $this->collection = $db->selectCollection('MongoScheduler');
+
+        $scheduler = new MongoScheduler($this->collection);
 
         $schedulerMiddleware = new SchedulerMiddleware($scheduler);
 
         $this->commandBus = new CommandBus([$schedulerMiddleware, $handlerMiddleware]);
+    }
+
+    /**
+     * Drop any leftover test commands
+     */
+    public function tearDown()
+    {
+        $con = new MongoClient('mongodb://localhost');
+        $db = $con->selectDB('ConnectHollandTacticianSchedulerTest');
+        $db->dropCollection('MongoScheduler');
     }
 
     /**
@@ -73,11 +95,11 @@ class SchedulerMiddlewareTest extends AbstractFileBasedSchedulerTest
     public function testSchedulingCommand()
     {
         $command = new ScheduledCommand();
-        $command->setTimestamp(time() + 2);
+        $command->setTimestamp(time() + 1);
         $this->commandBus->handle($command);
 
         $this->assertNotContains('handleScheduledCommand', $this->methodHandler->getMethodsInvoked());
-        sleep(2);
+        sleep(1);
         $this->commandBus->handle(new ExecuteScheduledCommandsCommand($this->commandBus));
         $this->assertContains('handleScheduledCommand', $this->methodHandler->getMethodsInvoked());
     }
@@ -91,5 +113,23 @@ class SchedulerMiddlewareTest extends AbstractFileBasedSchedulerTest
         $command = new ScheduledCommand();
         $command->setTimestamp(time() - 1);
         $this->commandBus->handle($command);
+    }
+
+    /**
+     * Tests if a stateful command is executed and marked succesful
+     */
+    public function testStatefulCommand()
+    {
+        $command = new StatefulCommand();
+        $command->setTimestamp(time() + 1);
+        $this->commandBus->handle($command);
+
+        $this->assertNotContains('handleStatefulCommand', $this->methodHandler->getMethodsInvoked());
+        sleep(1);
+        $this->commandBus->handle(new ExecuteScheduledCommandsCommand($this->commandBus));
+        $this->assertContains('handleStatefulCommand', $this->methodHandler->getMethodsInvoked());
+
+        $resultCommand = $this->collection->findOne();        
+        $this->assertEquals('succeeded', $resultCommand['state']);
     }
 }

--- a/tests/Scheduler/MongoSchedulerTest.php
+++ b/tests/Scheduler/MongoSchedulerTest.php
@@ -1,8 +1,10 @@
 <?php
 namespace ConnectHolland\Tactician\SchedulerPlugin\Scheduler\Tests;
 
+use ConnectHolland\Tactician\SchedulerPlugin\Command\ScheduledCommandInterface;
 use ConnectHolland\Tactician\SchedulerPlugin\Scheduler\MongoScheduler;
 use ConnectHolland\Tactician\SchedulerPlugin\Tests\Fixtures\Command\ScheduledCommand;
+use ConnectHolland\Tactician\SchedulerPlugin\Tests\Fixtures\Command\StatefulCommand;
 use MongoClient;
 use MongoId;
 use PHPUnit_Framework_TestCase;
@@ -26,15 +28,16 @@ class MongoSchedulerTest extends PHPUnit_Framework_TestCase
 
     /**
      * testScheduleCommand
+     *
+     * @dataProvider provideTestCommands
      */
-    public function testScheduleCommand()
+    public function testScheduleCommand(ScheduledCommandInterface $command)
     {
         $con = new MongoClient('mongodb://localhost');
         $db = $con->selectDB('ConnectHollandTacticianSchedulerTest');
         $collection = $db->selectCollection('MongoScheduler');
         $scheduler = new MongoScheduler($collection);
 
-        $command = new ScheduledCommand();
         $command->setTimestamp(time() + 1);
         $identifier = $scheduler->schedule($command);
 
@@ -68,5 +71,47 @@ class MongoSchedulerTest extends PHPUnit_Framework_TestCase
         $stored = $collection->findOne(['_id' => new MongoId($identifier)]);
 
         $this->assertEmpty($stored);
+    }
+
+    /**
+     * Tests that stateful commands are kept
+     */
+    public function testStatefulCommandsAreKept()
+    {
+        $con = new MongoClient('mongodb://localhost');
+        $db = $con->selectDB('ConnectHollandTacticianSchedulerTest');
+        $collection = $db->selectCollection('MongoScheduler');
+        $scheduler = new MongoScheduler($collection);
+
+        $command = new StatefulCommand();
+        $command->setTimestamp(time() + 1);
+        $identifier = $scheduler->schedule($command);
+        $nothing = $scheduler->getCommands();
+        $this->assertEquals(0, count($nothing));
+        sleep(1);
+
+        $todo = $scheduler->getCommands();
+        $this->assertEquals(1, count($todo));
+        $this->assertEquals('executing', $todo[0]->getFiniteState());
+
+        $stored = $collection->findOne(['_id' => new MongoId($identifier)]);
+
+        $this->assertNotEmpty($stored);
+
+        $dontExecuteTwice = $scheduler->getCommands();
+        $this->assertEquals(0, count($dontExecuteTwice));
+    }
+
+    /**
+     * Provide test commands
+     *
+     * @return array
+     */
+    public function provideTestCommands()
+    {
+        return [
+            [new ScheduledCommand()],
+            [new StatefulCommand()]
+        ];
     }
 }


### PR DESCRIPTION
This PR optionally adds states to commands. Stateful commands are kept in the scheduler, if the scheduler is stateful aware. The mongo scheduler is stateful aware. This allows you to inspect which commands failed and which succeeded. 

This closes #4 
