### PR TITLE
Fixed typo in docblock getTimestamp() ScheduledCommandInterface

### DIFF
--- a/src/Command/ScheduledCommandInterface.php
+++ b/src/Command/ScheduledCommandInterface.php
@@ -23,7 +23,7 @@ interface ScheduledCommandInterface
     /**
      * getTimestamp.
      *
-     * SGts the timestamp when this command should be executed
+     * Gets the timestamp when this command should be executed
      *
      * @since 1.0
      *


### PR DESCRIPTION
Fixed typo SGts -> Gets ;)
